### PR TITLE
Repair height for Chrome.

### DIFF
--- a/app/styles/app.styl
+++ b/app/styles/app.styl
@@ -46,6 +46,7 @@ x-layout {
 
     > section {
         padding: 45px 0 75px;
+        height: 100%;
     }
 
     > footer {


### PR DESCRIPTION
The browser window is not extended to the whole. It occurs only in Chrome.

![Example](https://dl.dropboxusercontent.com/u/103345209/Screenshots/Screenshot%202014-06-14%2017.17.54.png)
