### PR TITLE
http:// in the beginning of new URL should not be mandatory.

### DIFF
--- a/app/scripts/controllers/podcast_new_controller.js
+++ b/app/scripts/controllers/podcast_new_controller.js
@@ -6,6 +6,10 @@ HighFidelity.PodcastNewController = Ember.ObjectController.extend({
     actions: {
         create: function(url) {
             if (url) {
+                if (!url.match(/^http[s]?:\/\//i)) {
+                  url = 'http://' + url;
+                }
+
                 this.set('rssURL', url);
             }
 


### PR DESCRIPTION
Default to 'http://' in the beginning of URL, if it is not there
already.

Fixes #43
