### PR TITLE
UI improvements for touch and forward/rewind buttons.

### DIFF
--- a/app/scripts/controllers/player_controller.js
+++ b/app/scripts/controllers/player_controller.js
@@ -28,6 +28,16 @@ HighFidelity.PlayerController = Ember.ObjectController.extend({
             $('#audio-player')[0].play();
             episode.set('isPlaying', true);
         },
+        
+        rewind: function(episode) {
+            $('#audio-player')[0].currentTime -= 15;
+            episode.set('playbackPosition', $('#audio-player')[0].currentTime);
+        },
+        
+        forward: function(episode) {
+            $('#audio-player')[0].currentTime += 15;
+            episode.set('playbackPosition', $('#audio-player')[0].currentTime);
+        },
 
         setEpisode: function(episode) {
             var _this = this;

--- a/app/styles/player.styl
+++ b/app/styles/player.styl
@@ -40,6 +40,13 @@
         padding-bottom: 5px;
         text-align: center;
         
+        .forward, .backward {
+            cursor: pointer;
+            font-size: 30px;
+            padding: 0 15px;
+            color: #777;
+        }
+        
         .play-pause {
             cursor: pointer;
             font-size: 30px;

--- a/app/templates/player.hbs
+++ b/app/templates/player.hbs
@@ -12,6 +12,10 @@
     <div class="episode-name">{{name}}</div>
     
     <div class="player-controls">
+      <a {{action rewind model}} class="backward">
+        <i class="fa fa-backward"></i>
+      </a>
+      
       {{#if isPlaying}}
         <a {{action pause model}} class="play-pause">
           <i class="fa fa-pause"></i>
@@ -21,6 +25,10 @@
           <i class="fa fa-play"></i>
         </a>
       {{/if}}
+      
+      <a {{action forward model}} class="forward">
+        <i class="fa fa-forward"></i>
+      </a>
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION
I've increased the size of the pause button so it's easier to tap on touch devices. I've also made a few style changes.

There are also rewind and fast-forward buttons. They each rewind/fast-forward the audio by 15 seconds. This tends to be the default for podcast apps but there could be a setting (or you could tweak to your liking).

No worries if you don't want these changes. I've been using the app quite a bit on my Firefox phone and wanted to make the changes for myself anyway.
