### PR TITLE
Fix indefinite loading on incorrect Podcast URL.

### DIFF
--- a/app/scripts/controllers/podcast_new_controller.js
+++ b/app/scripts/controllers/podcast_new_controller.js
@@ -1,5 +1,6 @@
 HighFidelity.PodcastNewController = Ember.ObjectController.extend({
     isAdding: false,
+    isInErrorState: false,
 
     rssURL: '',
 

--- a/app/scripts/models/podcast_model.js
+++ b/app/scripts/models/podcast_model.js
@@ -162,7 +162,7 @@ HighFidelity.Podcast = DS.Model.extend({
                 });
             }, function(error) {
                 console.error('Could not download podcast', error);
-                _this.destroyRecord();
+                _this.destroyRecord().then(reject);
             });
         });
     },
@@ -196,6 +196,9 @@ HighFidelity.Podcast.createFromController = function(controller, rssURL) {
             controller.set('isAdding', false);
             controller.set('rssURL', '');
             controller.transitionToRoute('podcast', podcast);
+        }, function() {
+            controller.set('isAdding', false);
+            controller.set('isInErrorState', true);
         });
     });
 };

--- a/app/scripts/views/progress_bar_view.js
+++ b/app/scripts/views/progress_bar_view.js
@@ -3,7 +3,7 @@ HighFidelity.ProgressBarView = Ember.View.extend({
         mouseDown: function(event) {
             console.log(event, this);
             return;
-            this.set('isScrubberDragging', true);
+            // this.set('isScrubberDragging', true);
             // this.seekTo(this.event.pageX);
         },
 

--- a/app/styles/podcasts.styl
+++ b/app/styles/podcasts.styl
@@ -17,3 +17,7 @@
 .podcast {
     padding: 5px;
 }
+
+.error {
+    color: orangered;
+}

--- a/app/templates/podcast/new.hbs
+++ b/app/templates/podcast/new.hbs
@@ -1,5 +1,12 @@
 <h2>{{t podcast.addRSSFeed}}</h2>
 
+{{#if isInErrorState}}
+  <div class="error">
+    <p>Encountered an error while adding Podcast.<p>
+    <p>Is the Podcast URL valid?</p>
+  </div>
+{{/if}}
+
 {{input type="url" value=rssURL placeholder="Podcast URL"}}
 <button {{action create}}>{{t podcast.add}}</button>
 


### PR DESCRIPTION
If an incorrect URL is entered while trying to add a podcast, the app screen never leaves the `loading` screen.
This PR contains a fix to the issue but without much styling.

Fixes #42 