### PR TITLE
Catalan translation

### DIFF
--- a/app/locales/ca/config.js
+++ b/app/locales/ca/config.js
@@ -1,0 +1,16 @@
+// Ember-I18n inclues configuration for common locales. Most users
+// can safely delete this file. Use it if you need to override behavior
+// for a locale or define behavior for a locale that Ember-I18n
+// doesn't know about.
+export default {
+  // rtl: [true|FALSE],
+  //
+  // pluralForm: function(count) {
+  //   if (count === 0) { return 'zero'; }
+  //   if (count === 1) { return 'one'; }
+  //   if (count === 2) { return 'two'; }
+  //   if (count < 5) { return 'few'; }
+  //   if (count >= 5) { return 'many'; }
+  //   return 'other';
+  // }
+};

--- a/app/locales/ca/translations.js
+++ b/app/locales/ca/translations.js
@@ -1,0 +1,30 @@
+export default {
+	// catalan by @caos30
+	"app": {
+	    "title": 'Podcasts',
+	},
+	"episode": {
+	    "episodes": 'Episodis',
+	    "new": 'Nou',
+	},
+	"podcast": {
+	    "add": 'Afegir',
+	    "addOne": 'Voleu afegir-ne un?',
+	    "addRSSFeed": 'Afegir font RSS',
+	    "newToPodcasts": 'Us estreneu en els podcasts?',
+	    "noneFound": "No s'ha trobat podcasts.",
+	    "recommendations": 'Aquestes són les nostres recomanacions:',
+	},
+	"search": {
+	    "find": 'Cercar',
+	    "noResults": 'Cap resultat.',
+	    "placeholder": 'Nom del podcats o paraules clau',
+	    "searchForAPodcast": 'Cercar un podcast',
+	    "subscribe": "Subscriure's a {{podcast}}?",
+	},
+	"tabs": {
+	    "myPodcasts": 'Els meus podcasts',
+	    "popular": 'Popular',
+	    "search": 'Cercar',
+	}
+};

--- a/app/locales/ca/translations.js
+++ b/app/locales/ca/translations.js
@@ -14,6 +14,7 @@ export default {
 	    "newToPodcasts": 'Us estreneu en els podcasts?',
 	    "noneFound": "No s'ha trobat podcasts.",
 	    "recommendations": 'Aquestes són les nostres recomanacions:',
+	    "URLplaceholder": "URL del podcast",
 	},
 	"search": {
 	    "find": 'Cercar',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'New to Podcasts?',
         "noneFound": 'No podcasts found.',
         "recommendations": 'Check out our recommendations:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'Find',

--- a/app/locales/eo/translations.js
+++ b/app/locales/eo/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'Ĉu malkutimas podkastojn?',
         "noneFound": 'Neniu podkasto trovata.',
         "recommendations": 'Kontrolu niajn rekomendojn:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'Trovi',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -14,6 +14,7 @@ export default {
 	    "newToPodcasts": 'Nuevo en los podcast?',
 	    "noneFound": 'No se encontraron podcast.',
 	    "recommendations": 'Estas son nuestras recomendaciones:',
+	    "URLplaceholder": "URL del podcast",
 	},
 	"search": {
 	    "find": 'Buscar',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'Vous ne connaissez pas de Podcasts?',
         "noneFound": 'Aucun podcast trouvé.',
         "recommendations": 'Voici nos recommandations:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'chercher',

--- a/app/locales/gl/translations.js
+++ b/app/locales/gl/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'Novo nos podcast?',
         "noneFound": 'Non se atoparon podcast.',
         "recommendations": 'Mire as nosas recomendacións:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'Buscar',

--- a/app/locales/it/translations.js
+++ b/app/locales/it/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'Nuovo ai podcast?',
         "noneFound": 'Nessun podcast trovato.',
         "recommendations": 'Controlla i nostri consigli:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'Trova',

--- a/app/locales/pl/translations.js
+++ b/app/locales/pl/translations.js
@@ -13,6 +13,7 @@ export default {
         "newToPodcasts": 'Nowe do podcastu?',
         "noneFound": 'Nie znaleziono podcastów.',
         "recommendations": 'Sprawdź nasze rekomendacje:',
+        "URLplaceholder": "podcast URL",
     },
     "search": {
         "find": 'Szukaj',

--- a/app/templates/podcasts/new.hbs
+++ b/app/templates/podcasts/new.hbs
@@ -9,7 +9,7 @@
   {{/if}}
 
   <div class="ui input">
-    {{input type="url" value=rssURL placeholder="Podcast URL"}}
+    {{input type="url" value=rssURL placeholder=(t "podcast.URLplaceholder")}}
   </div>
   <button class="ui button" {{action 'create'}}>{{t "podcast.add"}}</button>
 


### PR DESCRIPTION
I've made 2 contributtions:

1) added locale texts for catalan (ca)

2) added a new text label for the placeholder on the view podcast/new: podcast.URLplaceholder

Note: i've doubts about is it correct how i proceed with this second task. I means, i added the use of the new text label in the new.hsb, and also added its CORRECT translation on:

/app/locales/ca/translations.js
/app/locales/es/translations.js
/app/locales/en/translations.js

but also added the english translation to the other locales files... is this correct? Please, i would like an answer for do it well for future text labels in locales ;)

Indeed, i love this app. Could i work on make some minor improvements in CSS? i saw some minor issues.

Oh, and finally, i found 2 rare things:

A) when i execute the command "ember build" the /dist/manifest.webapp file generated has wrong the paths to index.html and to icons. It puts for example:

  "launch_path": "/high-fidelity/index.html",

instead of:

  "launch_path": "/index.html",

and then the desktop Firefox simulator (WebIDE) cannot run the app if you don't manually change that error :|

B) the second rare thing is that the great "search icon" on top toolbar in the app (once running in the FXOS simulator) point to the "add new url podcast feed" instead of to point to the "search podcasts". In this sense, the UI in this "master" branch is quite different from the version of the app that i've installed today from Marketplace... ¿?¿?¿? That mktp version has the menu at bottom (for example) and the GitHub version has it at top. Maybe i'm not understanding something?

I must put in clear that i'm a newbie in FXOS apps development, so please my apologies if i'm asking obvious things. Anyway, thanks in advance for your help.