### PR TITLE
Get Ember bugfix for major jQuery assertion error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "high-fidelity",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "1.13.13",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.5",


### PR DESCRIPTION
Newcomers doing `bower install` currently resolve to jQuery 1.12; in [emberjs/ember.js](https://github.com/rwjblue/ember.js/commit/a9ac424d86ebd472f48abd736cb20dccff991d7b) there is a silly jQuery detection assert error right in the framework loading sequence, resulting in a major fail as Ember cannot finish loading. 

Without the bugfix, [Ember apps with jQuery > 1.11 fail without even being able to load their app](ember-cli/ember-cli#5316). Indeed, I couldn't even run the tests on master. This results in a confusing error message, since 1.12 should be just fine (and of course it is):

```Uncaught Error: Assertion Failed: Ember Views require jQuery between 1.7 and 2.1```

This is fixed by updating to [emberjs/ember.js v1.13.13](https://github.com/emberjs/ember.js/blob/a3e5bb96b9241c56e66cb6d749ecd644d7b113bf/CHANGELOG.md).